### PR TITLE
Smaller hero text

### DIFF
--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -2,22 +2,24 @@
   background-size: cover;
   background-repeat: no-repeat;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 30em;
+  min-height: 32em;
+  background-position: 50% 20%;
+  flex-direction: column-reverse;
 }
 .hero-content {
   background-color: transparentize($text-color, .6);
-  margin-left: 20%;
+  margin-left: 10%;
   padding-top: 20px;
   text-align: center;
-  width: 60%;
+  width: 80%;
+  margin-bottom: 20px;
 }
 .hero-content h1 {
   color: white;
   font-size: 36px;
   font-weight: 100;
   line-height: 50px;
+  margin-top: 0;
   margin-bottom: 0;
 }
 .hero-content .usa-button {


### PR DESCRIPTION
Shrinks the hero text to show more of the photo:

<img width="1077" alt="screen shot 2015-09-10 at 4 29 46 pm" src="https://cloud.githubusercontent.com/assets/170641/9800185/90daf2c0-57d9-11e5-8704-1592e1169f6d.png">
<img width="395" alt="screen shot 2015-09-10 at 4 32 56 pm" src="https://cloud.githubusercontent.com/assets/170641/9800195/9f0f221c-57d9-11e5-982b-72e823a41899.png">

Closes #7
