### PR TITLE
Remove padding for nav items on mobile

### DIFF
--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -48,6 +48,9 @@ li.usa-menu-item {
   color: $button-text-color;
 }
 @media (max-width: 600px) {
+  .usa-site-navbar .usa-grid {
+    padding: 0;
+  }
   #logo {
     height: auto;
     margin-top: 1em;

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -64,6 +64,9 @@ li.usa-menu-item {
   li.usa-menu-item {
     display: block;
   }
+  .usa-menu-item a {
+    padding: 0;
+  }
 }
 li.usa-menu-item:last-child {
   margin-right: 0;

--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -47,13 +47,18 @@ li.usa-menu-item {
   background-color: $button-color;
   color: $button-text-color;
 }
-@media (max-width: 500px) {
+@media (max-width: 600px) {
+  #logo {
+    height: auto;
+    margin-top: 1em;
+    max-width: none;
+  }
+  .usa-nav-list {
+    margin: 1em 0;
+  }
   #logo,.usa-nav-list {
     float: none;
     text-align: center;
-  }
-  #logo img {
-    width: 90px;
   }
   ul.usa-nav-list {
     bottom: 0;
@@ -61,11 +66,8 @@ li.usa-menu-item {
     right: 0;
     width: 100%;
   }
-  li.usa-menu-item {
-    display: block;
-  }
   .usa-menu-item a {
-    padding: 0;
+    padding: 0.4em;
   }
 }
 li.usa-menu-item:last-child {


### PR DESCRIPTION
Removes the padding from nav bar menu items so that users can ensure they touch the desired link.

To close #33 