### PR TITLE
Use navigation.json

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,8 @@ footer:
 
 # Build settings
 markdown: kramdown
+include:
+  - _navigation.json
 exclude:
   - CONTRIBUTING.md
   - LICENSE.md

--- a/_navigation.json
+++ b/_navigation.json
@@ -1,0 +1,37 @@
+---
+---
+
+[
+  {% for nav in site.data.navbar %}
+    {
+      {% for page in site.pages %}
+        {% if nav.permalink == page.permalink %}
+          {% assign href = page.path %}
+        {% endif %}
+      {% endfor %}
+      "title": "{{ nav.name }}",
+      "href": "{{ href }}"
+
+      {% if nav.permalink == '/work/' %},
+      "children": [
+
+        {% for project in site.data.projects %}
+        {
+          {% for page in site.pages %}
+            {% if page.permalink == project.link %}
+              {% assign h = page.path %}
+            {% endif %}
+          {% endfor %}
+          "title": "{{ project.title }}",
+          "href": "{{ h }}"
+        }
+        {% if forloop.rindex != 1 %}, {% endif %}
+        {% endfor %}
+
+      ]
+      {% endif %}
+
+    }
+    {% if forloop.rindex != 1 %}, {% endif %}
+  {% endfor %}
+]

--- a/_navigation.json
+++ b/_navigation.json
@@ -16,22 +16,29 @@
       "children": [
 
         {% for project in site.data.projects %}
-        {
-          {% for page in site.pages %}
-            {% if page.permalink == project.link %}
-              {% assign h = page.path %}
-            {% endif %}
-          {% endfor %}
-          "title": "{{ project.title }}",
-          "href": "{{ h }}"
-        }
-        {% if forloop.rindex != 1 %}, {% endif %}
+          {
+            {% for page in site.pages %}
+              {% if page.permalink == project.link %}
+                {% assign h = page.path %}
+              {% endif %}
+            {% endfor %}
+            "title": "{{ project.title }}",
+            "href": "{{ h }}"
+          }
+          {% if forloop.rindex != 1 %}, {% endif %}
         {% endfor %}
-
       ]
       {% endif %}
 
     }
     {% if forloop.rindex != 1 %}, {% endif %}
-  {% endfor %}
+  {% endfor %},
+  {
+    "title": "Navbar structure",
+    "href": "_data/navbar.yml"
+  },
+  {
+    "title": "Projects",
+    "href": "_data/projects.yml"
+  }
 ]


### PR DESCRIPTION
Now that Federalist supports a [Pages schema](https://github.com/18F/federalist/wiki/Pages-schema), I added a `_navigation.json` to this project.

This will change the way that Federalist displays the file listing for this project to only show the files that content editors using Federalist might care about. Right now those are:

1. The pages declared in the navbar file
2. The projects declared in the `projects.yml` file, nested underneath the "Work" page
3. The `projects.yml` and `navbar.yml` files