### PR TITLE
Updating _navigation.json to use new schema

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -1,12 +1,19 @@
-- name: About
-  permalink: '/about/'
-- name: Approach
-  permalink: '/approach/'
-- name: Work
-  permalink: '/work/'
-- name: Resources
-  permalink: '/resources/'
-- name: Connect
-  permalink: '/connect/'
-- name: Apply
-  permalink: '/apply/'
+assigned:
+  - text: About
+    permalink: '/about/'
+    href: '/pages/about.md'
+  - text: Approach
+    permalink: '/approach/'
+    href: '/pages/approach.md'
+  - text: Work
+    permalink: '/work/'
+    href: '/pages/work.md'
+  - text: Resources
+    permalink: '/resources/'
+    href: '/pages/resources.md'
+  - text: Connect
+    permalink: '/connect/'
+    href: '/pages/contact.md'
+  - text: Apply
+    permalink: '/apply/'
+    href: '/pages/apply.md'

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,11 +22,11 @@
         </a>
       </div>
       <ul class="usa-nav-list usa-unstyled-list">
-        {% assign navs = site.data.navbar %}
+        {% assign navs = site.data.navbar.assigned %}
 
         {% for nav in navs %}
           <li class="usa-menu-item">
-            <a href="{{ nav.permalink | prepend: site.baseurl }}">{{ nav.name }}</a>
+            <a href="{{ nav.permalink | prepend: site.baseurl }}">{{ nav.text }}</a>
           </li>
         {% endfor %}
       </ul>

--- a/_navigation.json
+++ b/_navigation.json
@@ -2,43 +2,29 @@
 ---
 
 [
-  {% for nav in site.data.navbar %}
-    {
-      {% for page in site.pages %}
-        {% if nav.permalink == page.permalink %}
-          {% assign href = page.path %}
-        {% endif %}
+  {% for nav in site.data.navbar.assigned %}
+  {
+    "title": "{{ nav.text }}",
+    "permalink": "{{ nav.permalink }}",
+    "href": "{{ nav.href }}"
+
+    {% if nav.children %},
+    "children": [
+      {% for child in nav.children %}
+      {
+        "title": "{{ child.text }}",
+        "permalink": "{{ child.permalink }}",
+        "href": "{{ child.href }}"
+
+      } {% if forloop.rindex != 1 %}, {% endif %}
       {% endfor %}
-      "title": "{{ nav.name }}",
-      "href": "{{ href }}"
+    ]
+    {% endif %}
 
-      {% if nav.permalink == '/work/' %},
-      "children": [
-
-        {% for project in site.data.projects %}
-          {
-            {% for page in site.pages %}
-              {% if page.permalink == project.link %}
-                {% assign h = page.path %}
-              {% endif %}
-            {% endfor %}
-            "title": "{{ project.title }}",
-            "href": "{{ h }}"
-          }
-          {% if forloop.rindex != 1 %}, {% endif %}
-        {% endfor %}
-      ]
-      {% endif %}
-
-    }
-    {% if forloop.rindex != 1 %}, {% endif %}
-  {% endfor %},
-  {
-    "title": "Navbar structure",
-    "href": "_data/navbar.yml"
   },
+  {% endfor %}
   {
-    "title": "Projects",
-    "href": "_data/projects.yml"
+    "title": "Navigation bar data",
+    "href": "_data/navbar.yml"
   }
 ]


### PR DESCRIPTION
We had updated _navigation.json in the original template repo but didn't submit a pull request to update it here. As a result, the editor interface was breaking in Federalist as `_navigation.json` didn't have the proper shape.

We think this also causes 18f/federalist#372.